### PR TITLE
feat: show saving state on button and disable editing during download

### DIFF
--- a/server/public/static/highlightEditor.js
+++ b/server/public/static/highlightEditor.js
@@ -37,7 +37,7 @@ export function initHighlightEditor(highlightBarContainer, finalVideo, uploadedF
     const saveCustomBtn = document.createElement("button");
     saveCustomBtn.id = "saveCustomBtn";
     saveCustomBtn.className = "primary-btn";
-    saveCustomBtn.innerHTML = '<i class="fas fa-download"></i> 결과 다운로드';
+    saveCustomBtn.innerHTML = '<i class="fas fa-download"></i> 편집 결과 다운로드';
     saveCustomBtn.style.display = "none";
 
     const cancelEditBtn = document.createElement("button");
@@ -393,9 +393,19 @@ export function initHighlightEditor(highlightBarContainer, finalVideo, uploadedF
         console.log("총 숏폼 길이:", totalDuration.toFixed(1) + "초");
 
         try {
+            // 저장(다운로드) 진행 UI
             saveCustomBtn.disabled = true;
-            saveCustomBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> 준비 중...';
+            saveCustomBtn.setAttribute('aria-busy', 'true');
+            saveCustomBtn.style.color = '#fff'; // 흰 글씨
+            saveCustomBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>&nbsp; 저장 중...';
             cancelEditBtn.disabled = true;
+
+            // 편집 차단
+            highlightBarContainer.style.pointerEvents = "none";
+            // 버튼은 saveCustomBtn만 활성, 나머지는 비활성
+            resultCard.querySelectorAll("button").forEach(btn => {
+                if (btn !== saveCustomBtn) btn.disabled = true;
+            });
 
             // 1) 다운로드 전용 엔드포인트 우선 시도
             let res = await fetch(`/download/highlights`, {
@@ -428,7 +438,7 @@ export function initHighlightEditor(highlightBarContainer, finalVideo, uploadedF
             const a = document.createElement("a");
             a.href = url;
             
-            // (영상제목)_edited.mp4 로 단순화
+            // (영상제목)_edited.mp4 로 저장
             a.download = `${uploadedFileName.replace(/\.[^/.]+$/, "")}_edited.mp4`;
             document.body.appendChild(a);
             a.click();
@@ -450,10 +460,15 @@ export function initHighlightEditor(highlightBarContainer, finalVideo, uploadedF
             console.error("다운로드 오류:", err);
             showToast(`다운로드 실패: ${err.message}`, "error");
         } finally {
-            // 버튼 상태 복원
-            saveCustomBtn.innerHTML = '<i class="fas fa-download"></i> 결과 다운로드';
+            // 버튼/상호작용 복원
+            saveCustomBtn.innerHTML = '<i class="fas fa-download"></i> 편집 결과 다운로드';
+            saveCustomBtn.style.color = ''; // 기본색
+            saveCustomBtn.removeAttribute('aria-busy');
             saveCustomBtn.disabled = false;
             cancelEditBtn.disabled = false;
+
+            highlightBarContainer.style.pointerEvents = "auto";
+            resultCard.querySelectorAll("button").forEach(btn => (btn.disabled = false));
         }
     }
 


### PR DESCRIPTION
## Related Issues
> closes #9 

<br>

## Overview
> Added a saving indicator and temporarily disabled editing during the download process  
> to prevent user confusion and improve overall UX clarity.

<br>

## Details of Changes
- [x] Added spinner and “저장 중...” text to the download button while processing  
- [x] Disabled highlight bar interactions and other buttons during save/download  
- [x] Restored normal state once the process completes or fails  

Enhances user feedback and prevents accidental edits during the export process.

<br>

## Screenshots (optional)
<img width="531" height="518" alt="image" src="https://github.com/user-attachments/assets/b119d709-d178-4c28-93b7-1450bc0d5bf6" />

> **Before:** The user couldn’t tell if saving was in progress  
> **After:** The button now shows “저장 중...” with a spinner animation

<br>

## Review Notes (optional)
> Please confirm that the spinner animation and text display correctly across browsers, and that all buttons are properly re-enabled after completion.

<br>

## Additional Notes (optional)
> Related file: `public/static/highlightEditor.js`  
> Label: `FEATURE`
