### PR TITLE
refactor: separate segment scoring and selection logic into segment_importance.py

### DIFF
--- a/src/knapsack_module.py
+++ b/src/knapsack_module.py
@@ -89,7 +89,7 @@ def greedy_submodular_knapsack_selection(segment_ids, segment_vectors, importanc
     selected_ids = [segment_ids[j] for j in selected]
     return selected_ids, total_time
 
-def run_sub_knapsack_pipeline(feature_h5, scene_json, fps, output_sorted_combined_json, importance_weight, top_ratio=None, budget_time=None):
+def run_sub_knapsack_pipeline(feature_h5, scene_json, fps, output_sorted_combined_json, importance_weight, selected_json, top_ratio=None, budget_time=None):
     """
     Submodular + Knapsack 알고리즘을 사용하여 최적의 세그먼트 조합을 선택한다.
 
@@ -107,8 +107,6 @@ def run_sub_knapsack_pipeline(feature_h5, scene_json, fps, output_sorted_combine
     Returns:
         list: 최종적으로 선택된 세그먼트 객체(dict)들의 리스트
     """
-
-    print("\n[4/6]그리디 방식의 서브모듈러 + Knapsack 기반 세그먼트 선택 알고리즘 실행", flush=True)
     
     # h5_file = args.feature_h5  # pgl_module에서 사용한 feature 파일과 동일
     # output_h5_path = f"./features/{base_filename}.h5"
@@ -159,4 +157,6 @@ def run_sub_knapsack_pipeline(feature_h5, scene_json, fps, output_sorted_combine
     
     # selected_ids → 실제 segment 객체들로 변환
     selected_segments = [seg for seg in sorted_combined if seg["segment_id"] in selected_ids]
-    return selected_segments
+    
+    with open(selected_json, "w", encoding="utf-8") as f:
+        json.dump(selected_segments, f, indent=2, ensure_ascii=False)

--- a/src/pgl_module.py
+++ b/src/pgl_module.py
@@ -1,10 +1,8 @@
 import torch
-import json
+# import os
 import numpy as np
 import h5py
-import os
 from networks.pgl_sum.pgl_sum import PGL_SUM
-from knapsack_module import run_sub_knapsack_pipeline
 
 def load_h5_features(h5_path):
     # H5 파일에서 프레임 특징(feature)을 로드
@@ -33,128 +31,13 @@ def load_model_checkpoint(model, ckpt_path, device):
     return model
 
 
-def load_scene_segments(scene_json, fps, thr=0.5):
-    # 중복 없는 세그먼트 로드 (비정상 세그먼트는 invalid로 처리)
-    with open(scene_json, "r") as f:
-        segments = json.load(f)
-
-    for seg in segments:
-        seg["start_frame"] = int(seg["start_time"] * fps)
-
-    for i, seg in enumerate(segments):
-        if i < len(segments) - 1:
-            next_seg = segments[i + 1]
-            boundary_frame = next_seg["start_frame"]
-
-            frac = seg["end_time"] - int(seg["end_time"])
-            
-            if frac < thr:
-                seg["end_frame"] = boundary_frame - 1
-            else:
-                seg["end_frame"] = boundary_frame
-                next_seg["start_frame"] = boundary_frame + 1
-        else:
-            seg["end_frame"] = int(seg["end_time"] * fps) - 1
-
-        # 보정 대신 비정상 세그먼트는 제거 대상(invalid) 마킹
-        seg["invalid"] = seg["end_frame"] < seg["start_frame"]
-
-    return segments
-
-
-def save_segment_frame_scores_json(scores, scene_segments, output_json, fps):
-    # 프레임 점수 JSON 저장 (invalid 세그먼트 제외)
-    segment_scores = []
-
-    for seg in scene_segments:
-        if seg.get("invalid", False):
-            print(f"비정상 세그먼트 id={seg['segment_id']} (start_frame={seg['start_frame']} end_frame={seg['end_frame']}) 건너뜀.")
-            continue  # invalid 세그먼트 제외
-
-        start_frame = seg["start_frame"]
-        end_frame = min(seg["end_frame"], len(scores) - 1)
-
-        if start_frame >= len(scores):
-            continue
-
-        frame_scores = scores[start_frame: end_frame + 1]
-        if len(frame_scores) == 0:
-            continue
-
-        avg_score = float(np.mean(frame_scores))
-        max_score = float(np.max(frame_scores))
-        std_score = float(np.std(frame_scores))
-
-        segment_scores.append({
-            "segment_id": seg["segment_id"],
-            "start_time": seg["start_time"],
-            "end_time": seg["end_time"],
-            "frame_scores": frame_scores.tolist(),
-            "avg_score": avg_score,
-            "max_score": max_score,
-            "std_score": std_score
-        })
-
-    with open(output_json, "w", encoding="utf-8") as f:
-        json.dump(segment_scores, f, indent=2, ensure_ascii=False)
-
-    print(f"Segment scores JSON saved: {output_json}")
-    return segment_scores
-
-def save_sorted_segments_with_combined_score_json(segment_scores, alpha, std_weight, output_json):
-    # 각 세그먼트에 가중합(combined_score)을 계산한 후 내림차순으로 정렬하여 저장
-    for seg in segment_scores:
-        seg["combined_score"] = (seg["avg_score"] * alpha) + (seg["max_score"] * (1 - alpha)) - (std_weight * seg["std_score"])
-    sorted_segments = sorted(segment_scores, key=lambda x: x["combined_score"], reverse=True)
-    with open(output_json, "w") as f:
-        json.dump(sorted_segments, f, indent=2, ensure_ascii=False)
-    print(f"Sorted segments JSON saved (combined_score): {output_json}")
-    return sorted_segments
-
-# def save_segment_frame_ranges_json(scene_segments, segment_scores, fps, output_path):
-#     """
-#     세그먼트의 프레임 범위, 시간 및 가중합 점수를 저장
-#     """
-#     combined_score_dict = {seg["segment_id"]: seg.get("combined_score", None) for seg in segment_scores}
-#     frame_ranges = []
-#     for seg in scene_segments:
-#         start_frame = int(seg["start_time"] * fps)
-#         end_frame = int(seg["end_time"] * fps)
-#         combined_score = combined_score_dict.get(seg["segment_id"])
-#         frame_ranges.append({
-#             "segment_id": seg["segment_id"],
-#             "start_frame": start_frame,
-#             "end_frame": end_frame,
-#             "combined_score": round(combined_score, 5) if combined_score is not None else None,
-#             "start_time": seg["start_time"],
-#             "end_time": seg["end_time"]
-#         })
-#     with open(output_path, "w") as f:
-#         json.dump(frame_ranges, f, indent=2, ensure_ascii=False)
-#     print(f"세그먼트 프레임 + 시간 범위 JSON 저장 완료: {output_path}")
-#     return frame_ranges
-
-# def run_pgl_pipeline(
-
-def run_pgl_module(ckpt_path, feature_h5, scene_json, output_json, output_sorted_combined_json, fps=1.0, device="cpu", 
-                   alpha=0.7, std_weight=0.3, top_ratio=0.2, importance_weight=0.8, budget_time=None):
-
+def run_pgl_module(ckpt_path, feature_h5, device="cpu"):
     """
     PGL-SUM 모델을 사용하여 각 세그먼트의 중요도 점수를 계산하고, Knapsack 알고리즘으로 최종 세그먼트를 선택한다.
-
     Args:
         ckpt_path (str): 사전 학습된 PGL-SUM 모델의 체크포인트(.pkl) 파일 경로
         feature_h5 (str): 특징 벡터가 저장된 .h5 파일 경로
-        scene_json (str): 장면 시간 정보가 담긴 .json 파일 경로
-        output_json (str): 모든 세그먼트의 계산된 점수를 저장할 .json 파일 경로
-        output_sorted_combined_json (str): 점수 기준으로 정렬된 세그먼트를 저장할 .json 파일 경로
-        fps (float, optional): 비디오의 초당 프레임 수. 기본값: 1.0
         device (str, optional): 연산에 사용할 장치. 기본값: cpu
-        alpha (float, optional): 평균 점수와 최대 점수의 가중 평균 계산 시 사용될 가중치. 기본값: 0.7
-        std_weight (float, optional): 점수 계산 시 표준 편차에 적용될 패널티 가중치. 기본값: 0.3
-        top_ratio (float, optional): 최종 요약의 목표 비율. 기본값: 0.2
-        importance_weight (float, optional): Knapsack 선택 시 사용될 중요도 가중치. 기본값: 0.8
-        budget_time (float, optional): 최종 요약의 목표 시간을 직접 지정. 기본값: None
 
     Returns:
         list: 최종적으로 선택된 세그먼트 객체(dict)들의 리스트
@@ -162,19 +45,9 @@ def run_pgl_module(ckpt_path, feature_h5, scene_json, output_json, output_sorted
 
     print(f"사용 디바이스: {device}")
 
-# video_path로부터 base_filename (예: "shortbox") 결정
-    # base_filename = os.path.splitext(os.path.basename(args.video_path))[0]
-    # os.makedirs(f"./{base_filename}", exist_ok=True)
-
-    # 파일 경로 설정
-    # output_json_path = f"./{base_filename}/{base_filename}_segment_scores.json"
-    # output_sorted_combined_json_path = f"./{base_filename}/{base_filename}_sorted_combined.json"
-    # segment_frame_json_path = f"./{base_filename}/{base_filename}_segment_frame.json"
-    # pgl 파트에서 필요한 scene 세그먼트 JSON 파일 (미리 준비되어 있어야 함)
-    # scene_json_path = f"./{base_filename}/{base_filename}_scenes.json"
 
     # 모델 초기화 및 체크포인트 로드
-    
+
     model = PGL_SUM(input_size=1024, output_size=1024, num_segments=4, heads=8, fusion="add", pos_enc="absolute")
     model = load_model_checkpoint(model, ckpt_path, device)
     model.to(device).eval()
@@ -182,9 +55,4 @@ def run_pgl_module(ckpt_path, feature_h5, scene_json, output_json, output_sorted
     features = load_h5_features(feature_h5)
     scores = predict_scores(model, features, device=device)
 
-    scene_segments = load_scene_segments(scene_json, fps, thr=0.5)
-    segment_scores = save_segment_frame_scores_json(scores, scene_segments, output_json, fps)
-    save_sorted_segments_with_combined_score_json(segment_scores, alpha, std_weight, output_sorted_combined_json)
-
-    selected_segments = run_sub_knapsack_pipeline(feature_h5, scene_json, fps, output_sorted_combined_json, importance_weight, top_ratio, budget_time)
-    return selected_segments
+    return scores

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -8,11 +8,13 @@ os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
 from extract_features_module import extract_features_pipe
 from scene_detection_module import run_scene_detect_pipeline
 from pgl_module import run_pgl_module
+from segment_importance import run_segment_importance_pipeline
 from video_module import create_highlight_video
 from whisper_segmentor import process as whisper_process
 from refine_selected_segments import refine_selected_segments
 from visualize_module import run_visualize_pipeline
 from frame_score_plotter import visualize_all_segments_frame_scores
+from knapsack_module import run_sub_knapsack_pipeline
 
 from audio_module import extract_audio
 from transcript_module import reconstruct_highlight_transcripts
@@ -50,24 +52,30 @@ def run_pipeline(video_path, ckpt_path, output_dir, device="cuda", fps=1.0,
         print("\n[1/6] 특징 추출", flush=True)
         video_fps = extract_features_pipe(video_path, h5_path, device="cuda")
 
-    # 장면 분할
+    # 2. 중요도 기반 세그먼트 선택
+    print("\n[2/6] 대표 프레임별 중요도 점수 산출 (PGL‑SUM)", flush=True)
+    frame_scores = run_pgl_module(ckpt_path=ckpt_path, feature_h5=h5_path,device=device)
+
+    # 3. 장면 분할
     if os.path.exists(scene_json):
-        print("\n장면 분할 - 기존 파일 발견, 스킵", flush=True)
+        print("\n[3/6] 장면 분할 - 기존 파일 발견, 스킵", flush=True)
     else:
-        print("\n장면 분할", flush=True)
+        print("\n[3/6]TransNetV2로 장면 전환 감지 중...")
         run_scene_detect_pipeline(video_path, scene_json, video_fps)
 
-    # 4. 중요도 기반 세그먼트 선택
-    print("\n[3/6] 중요도 기반 상위 세그먼트 선택 (PGL‑SUM)", flush=True)
-    # [4/6] 과정은 knapsack_module.py 내에서 진행
-    selected_segments = run_pgl_module(
-        ckpt_path=ckpt_path, feature_h5=h5_path, scene_json=scene_json,
-        output_json=segment_json, output_sorted_combined_json=sorted_json,
-        fps=fps, device=device, alpha=alpha, std_weight=std_weight, top_ratio=top_ratio,
-        importance_weight=importance_weight, budget_time=budget_time
-    )
-    with open(selected_json, "w", encoding="utf-8") as f:
-        json.dump(selected_segments, f, indent=2, ensure_ascii=False)
+    print("\n[4/6]세그먼트 중요도 산출 및 세그먼트 선택")
+    run_segment_importance_pipeline(
+        scene_json=scene_json, frame_scores=frame_scores, 
+        output_json=segment_json, output_sorted_combined_json=sorted_json, 
+        alpha=alpha, std_weight=std_weight, fps=fps)
+
+    run_sub_knapsack_pipeline(
+        feature_h5=h5_path, scene_json=scene_json, fps=fps,
+        output_sorted_combined_json=sorted_json, importance_weight=importance_weight,
+        selected_json=selected_json, top_ratio=top_ratio, budget_time=None)
+
+
+    print("\n[5/6] Whisper 기반으로 경계 보정", flush=True)
 
     # 2. 오디오 추출
     audio_wav = extract_audio(video_path, output_dir, base)
@@ -80,7 +88,6 @@ def run_pipeline(video_path, ckpt_path, output_dir, device="cuda", fps=1.0,
         whisper_process(audio_wav, scene_json, whisper_json, model_size=model_size)
 
     # 5. 세그먼트 경계 보정
-    print("\n[5/6] Whisper 기반으로 경계 보정", flush=True)
     refine_selected_segments(selected_json, whisper_json, refined_json)
     
     # 6. 요약 영상 생성

--- a/src/scene_detection_module.py
+++ b/src/scene_detection_module.py
@@ -5,7 +5,6 @@ from transnetv2 import TransNetV2
 
 # TransNetV2를 이용한 장면 전환 감지
 def detect_scenes_transnetv2(video_path, threshold=0.5):
-    print("\n[2/6]TransNetV2로 장면 전환 감지 중...")
     model = TransNetV2()
     video_frames, single_frame_predictions, _ = model.predict_video(video_path)
     scene_changes = np.where(single_frame_predictions > threshold)[0]

--- a/src/segment_importance.py
+++ b/src/segment_importance.py
@@ -1,0 +1,164 @@
+# segment_importance.py
+# 장면 세그먼트별 중요도 점수를 계산하고 정렬하는 파이프라인 모듈
+ 
+import json
+import numpy as np
+
+def load_scene_segments(scene_json, fps, thr=0.5):
+    """
+    장면 구간 JSON을 불러와 각 세그먼트의 시작/끝 프레임을 계산하고,
+    비정상적인(구간이 겹치거나 역전된) 세그먼트를 invalid로 표시하는 함수.
+
+    Args:
+        scene_json (str): 장면 구간 정보(JSON 파일 경로)
+        fps (float): 비디오의 초당 프레임 수
+        thr (float): 경계 보정 기준값 (소수점 이하 경계가 thr보다 작을 경우 보정 적용)
+
+    Returns:
+        List[dict]: start_frame, end_frame, invalid 등이 포함된 세그먼트 리스트
+    """
+
+    # JSON 파일 로드
+    with open(scene_json, "r") as f:
+        segments = json.load(f)
+
+    # 각 세그먼트에 start_time(초)을 기반으로 start_frame 계산
+    for seg in segments:
+        seg["start_frame"] = int(seg["start_time"] * fps)
+
+    # 세그먼트 간 경계 프레임 계산 및 유효성 검사
+    for i, seg in enumerate(segments):
+        if i < len(segments) - 1:
+            next_seg = segments[i + 1]
+            boundary_frame = next_seg["start_frame"]
+
+            # end_time의 소수점 부분 (장면 경계가 애매할 때 처리하기 위함)
+            frac = seg["end_time"] - int(seg["end_time"])
+            
+            # 소수점 이하가 threshold보다 작으면 바로 이전 프레임까지
+            if frac < thr:
+                seg["end_frame"] = boundary_frame - 1
+            else:
+                # 경계 포함 처리
+                seg["end_frame"] = boundary_frame
+                next_seg["start_frame"] = boundary_frame + 1
+        else:
+            # 마지막 세그먼트는 end_time 기준으로 계산
+            seg["end_frame"] = int(seg["end_time"] * fps) - 1
+
+        # end_frame이 start_frame보다 작으면 비정상 세그먼트로 마킹
+        seg["invalid"] = seg["end_frame"] < seg["start_frame"]
+
+    return segments
+
+
+def save_segment_frame_scores_json(scores, scene_segments, output_json, fps):
+    """
+    각 세그먼트에 해당하는 프레임 구간의 점수를 추출하고,
+    평균, 최대, 표준편차 점수를 계산하여 JSON으로 저장하는 함수.
+
+    Args:
+        scores (List[float]): 프레임별 중요도 점수
+        scene_segments (List[dict]): 장면 세그먼트 리스트
+        output_json (str): 결과 JSON 파일 경로
+        fps (float): 초당 프레임 수
+
+    Returns:
+        List[dict]: 각 세그먼트의 점수 정보 리스트
+    """
+    segment_scores = []
+
+    for seg in scene_segments:
+        # invalid 세그먼트는 계산에서 제외
+        if seg.get("invalid", False):
+            print(f"비정상 세그먼트 id={seg['segment_id']} (start_frame={seg['start_frame']} end_frame={seg['end_frame']}) 건너뜀.")
+            continue
+
+        # 세그먼트 구간의 프레임 인덱스 계산
+        start_frame = seg["start_frame"]
+        end_frame = min(seg["end_frame"], len(scores) - 1)
+
+        # 세그먼트 시작이 전체 프레임 범위 밖이면 무시
+        if start_frame >= len(scores):
+            continue
+
+        # 프레임 구간별 점수 슬라이싱
+        frame_scores = scores[start_frame: end_frame + 1]
+        if len(frame_scores) == 0:
+            continue
+
+        # 평균, 최대, 표준편차 계산
+        avg_score = float(np.mean(frame_scores))
+        max_score = float(np.max(frame_scores))
+        std_score = float(np.std(frame_scores))
+
+        # 결과 구조화
+        segment_scores.append({
+            "segment_id": seg["segment_id"],
+            "start_time": seg["start_time"],
+            "end_time": seg["end_time"],
+            "frame_scores": frame_scores.tolist(),
+            "avg_score": avg_score,
+            "max_score": max_score,
+            "std_score": std_score
+        })
+
+    # JSON 파일로 저장
+    with open(output_json, "w", encoding="utf-8") as f:
+        json.dump(segment_scores, f, indent=2, ensure_ascii=False)
+
+    print(f"Segment scores JSON saved: {output_json}")
+    return segment_scores
+
+
+def save_sorted_segments_with_combined_score_json(segment_scores, alpha, std_weight, output_json):
+    """
+    평균, 최대, 표준편차를 이용해 각 세그먼트의 중요도(combined_score)를 계산하고,
+    내림차순 정렬하여 저장하는 함수.
+
+    Args:
+        segment_scores (List[dict]): 세그먼트별 점수 정보
+        alpha (float): 평균 점수 가중치 (0~1)
+        std_weight (float): 표준편차 패널티 가중치
+        output_json (str): 정렬 결과 저장 파일 경로
+
+    Returns:
+        List[dict]: combined_score 기준으로 정렬된 세그먼트 리스트
+    """
+    for seg in segment_scores:
+        # combined_score = α*평균 + (1-α)*최대 - (표준편차 가중치 * std)
+        seg["combined_score"] = (seg["avg_score"] * alpha) + (seg["max_score"] * (1 - alpha)) - (std_weight * seg["std_score"])
+    
+    # 중요도 내림차순 정렬
+    sorted_segments = sorted(segment_scores, key=lambda x: x["combined_score"], reverse=True)
+    
+    # JSON 파일로 저장
+    with open(output_json, "w") as f:
+        json.dump(sorted_segments, f, indent=2, ensure_ascii=False)
+    print(f"Sorted segments JSON saved (combined_score): {output_json}")
+    return sorted_segments
+
+
+def run_segment_importance_pipeline(scene_json, frame_scores, output_json, output_sorted_combined_json, alpha, std_weight, fps):
+    """
+    장면 세그먼트 및 프레임 점수를 기반으로 중요한 세그먼트를 추출하는 전체 파이프라인 함수
+
+    Args:
+        scene_json (str): 장면 시간 정보가 담긴 JSON 파일 경로
+        frame_scores (List[float]): 프레임별 중요도 점수 리스트
+        output_json (str): 모든 세그먼트의 계산된 점수를 저장할 JSON 파일 경로
+        output_sorted_combined_json (str): 정렬된 세그먼트를 저장할 JSON 파일 경로
+        alpha (float): 평균 점수에 대한 가중치 (0~1 사이)
+        std_weight (float): 표준 편차에 대한 패널티 가중치
+        fps (float): 비디오의 초당 (대표)프레임 수
+    """
+
+    # 세그먼트 리스트 로드 및 시간(초)을 프레임 번호(start_frame, end_frame)로 변환
+    scene_segments = load_scene_segments(scene_json, fps, thr=0.5)
+
+    # 세그먼트 별 점수 계산 및 저장
+    segment_scores = save_segment_frame_scores_json(frame_scores, scene_segments, output_json, fps)
+    
+    # combined score 기준으로 정렬 및 저장
+    save_sorted_segments_with_combined_score_json(segment_scores, alpha, std_weight, output_sorted_combined_json)
+ 

--- a/src/transcript_module.py
+++ b/src/transcript_module.py
@@ -15,11 +15,6 @@ def reconstruct_highlight_transcripts(
         output_json_path (str): 재구성된 자막을 저장할 JSON 파일 경로
     """
 
-    # 기존 파일 존재시 스킵
-    if os.path.exists(output_json_path):
-        print("\n요약 영상 자막 재구성 - 기존 파일 발견, 스킵", flush=True)
-        return
-
     print("\n요약 영상 자막 재구성 중...", flush=True)
     try:
         with open(refined_json_path, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Related Issues
> closes #16
<br>

## Overview
`run_pgl_module()` currently handles frame-level importance calculation, segment scoring and sorting, and segment selection within a single function. This makes module responsibilities unclear and reduces maintainability.
Segment scoring and sorting should be moved to a dedicated `segment_importance.py`,
and segment selection should be executed separately within the main pipeline for better modularity.
<br>

## Details of Changes
- [x] Remove segment scoring and sorting logic from `pgl_module.py`
- [x] Create a new `segment_importance.py` and move related functions there
- [x] Ensure segment selection is handled in the pipeline (not within `pgl_module`)
- [x] Update the pipeline flow to:
`extract_features → pgl_module → scene_detection → segment_importance → knapsack_module`
- [x] Adjust imports and function references accordingly

<br>

## Additional Notes (optional)
> Related files: `pgl_module.py`, `segment_importance.py`, `knapsack_module.py`, `main_pipeline.py`


