### PR TITLE
refactor: use importance_weight_used_by_pipeline from report.json instead of slider

### DIFF
--- a/server/public/static/pipelineRunner.js
+++ b/server/public/static/pipelineRunner.js
@@ -463,42 +463,33 @@ function updateSummaryMetricsFromServerData(data) {
 
   let summaryHtmlContent = "맞춤형 요약"; // 기본값
 
-  const sliderElement = document.getElementById('importanceSlider');
-  if (sliderElement) {
-    const sliderVal = parseFloat(sliderElement.value); // 0 (하이라이트) ~ 1 (스토리)
-    if (!isNaN(sliderVal)) {
-      const highlightRatioForText = Math.round((1 - sliderVal) * 100);
-      const storyRatioForText = Math.round(sliderVal * 100);
+  // 슬라이더 제거하고, importance_weight_used_by_pipeline 값 기준으로 계산
+  const importanceWeight = data.importance_weight_used_by_pipeline;
+  if (importanceWeight !== undefined && !isNaN(importanceWeight)) {
+    const highlightRatio = Math.round(importanceWeight * 100); // 1.0: 하이라이트
+    const storyRatio = Math.round((1 - importanceWeight) * 100); // 0.0: 스토리
 
-      console.log("Slider Value:", sliderVal);
-      console.log("Highlight Ratio:", highlightRatioForText, "Display:", `하이라이트 ${highlightRatioForText}%`);
-      console.log("Story Ratio:", storyRatioForText, "Display:", `스토리 ${storyRatioForText}%`);
+    const highlightTextDisplay = `하이라이트 ${highlightRatio}%`;
+    const storyTextDisplay = `스토리 ${storyRatio}%`;
 
-      const highlightTextDisplay = `하이라이트 ${highlightRatioForText}%`;
-      const storyTextDisplay = `스토리 ${storyRatioForText}%`;
     const primaryStyle = "color: var(--accent-color); font-weight: bold;";
     const secondaryStyle = "color: var(--dark-color); font-weight: normal;";
 
-      if (sliderVal === 0) {
+    if (importanceWeight === 1) {
       summaryHtmlContent = `<span style="${primaryStyle}">${highlightTextDisplay}</span>`;
-      } else if (sliderVal === 1) {
+    } else if (importanceWeight === 0) {
       summaryHtmlContent = `<span style="${primaryStyle}">${storyTextDisplay}</span>`;
-      } else if (sliderVal === 0.5) {
+    } else if (importanceWeight === 0.5) {
       summaryHtmlContent = `<span style="${secondaryStyle}"><b>${highlightTextDisplay}</b></span><br><span style="${secondaryStyle}"><b>${storyTextDisplay}</b></span>`;
     } else {
-        if (highlightRatioForText > storyRatioForText) {
+      if (highlightRatio > storyRatio) {
         summaryHtmlContent = `<span style="${primaryStyle}">${highlightTextDisplay}</span><br><span style="${secondaryStyle}">${storyTextDisplay}</span>`;
       } else {
         summaryHtmlContent = `<span style="${primaryStyle}">${storyTextDisplay}</span><br><span style="${secondaryStyle}">${highlightTextDisplay}</span>`;
-        }
       }
     }
   } else {
-    if (data && data.summary_type_text) {
-      summaryHtmlContent = data.summary_type_text; // 서버 제공 텍스트 사용
-    } else {
-      summaryHtmlContent = "요약 방식 정보 없음"; // 또는 다른 적절한 기본값
-    }
+    summaryHtmlContent = "요약 방식 정보 없음";
   }
 
   if (summaryScoreValueEl) {


### PR DESCRIPTION
## Related Issues
closes #24

<br>

## Overview
Refactored the logic in `updateSummaryMetricsFromServerData` to determine the summary type text using the server-provided  
`importance_weight_used_by_pipeline` field from `{fileName}_report.json` instead of relying on the client-side `importanceSlider`.

This improves consistency between UI and server-side processing and removes unnecessary DOM dependency.

<br>

## Details of Changes
- [x] Removed `importanceSlider` element dependency from summary display logic  
- [x] Added logic to use `importance_weight_used_by_pipeline` field from report JSON  
- [x] Implemented fallback for missing field (`"요약 방식 정보 없음"`)  
- [x] Ensured UI text and color consistency for summary type display  

<br>

## Screenshots (optional)
> N/A  No major UI layout change, only logic refactoring.

<br>

## Review Notes (optional)
- Please confirm that the new logic correctly reflects the expected ratio text (e.g., “하이라이트 70% / 스토리 30%”)  

<br>

## Additional Notes (optional)
- Updated section: `updateSummaryMetricsFromServerData` in `pipelineRunner.js`  
- Reference JSON structure: `{fileName}_report.json`