### PR TITLE
fix: ensure video_fps is properly defined when reusing existing feature files

### DIFF
--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import json
+import platform
 
 # KMP_DUPLICATE_LIB_OK 환경 변수 설정
 os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
@@ -22,10 +23,22 @@ from score_module import manage_quality_score
 from report_module import generate_summary_report
 from thumbnail_module import generate_thumbnails
 
+def get_video_fps(video_path):
+    IS_MACOS = platform.system() == 'Darwin'
+    if IS_MACOS:
+        import cv2
+        cap = cv2.VideoCapture(video_path)
+        fps = cap.get(cv2.CAP_PROP_FPS)
+        cap.release()
+    else:
+        from decord import VideoReader, cpu
+        vr = VideoReader(video_path, ctx=cpu(0))
+        fps = vr.get_avg_fps()
+    return fps
 
 def run_pipeline(video_path, ckpt_path, output_dir, device="cuda", fps=1.0,
-                 alpha=0.7, std_weight=0.3, top_ratio=0.2,
-                 model_size="base", importance_weight=0.8, budget_time=None):
+                alpha=0.7, std_weight=0.3, top_ratio=0.2,
+                model_size="base", importance_weight=0.8, budget_time=None):
 
     os.makedirs(output_dir, exist_ok=True)
     base = os.path.splitext(os.path.basename(video_path))[0]


### PR DESCRIPTION

## Related Issues
closes #22 

<br>

## Overview
Fixed an issue where `video_fps` was undefined when an existing feature file was found.
Added platform-specific FPS extraction logic to ensure stable scene detection and video processing.

<br>

## Details of Changes
- [x] Added `get_video_fps()` function with platform-aware handling. (macOS → OpenCV / others → decord)
- [x] Ensured `video_fps` is defined even when reusing pre-extracted feature files(.h5).
- [x] Improved pipeline stability for `run_scene_detect_pipeline` by passing correct FPS value.

<br>

## Screenshots (optional)
> N/A backend logic only.

<br>

## Review Notes (optional)
> Mention anything you’d like reviewers to focus on or get feedback about.  
> e.g., Need opinions on function naming or exception handling logic.

<br>

## Additional Notes (optional)
Tested on macOS and Linux. Verified end-to-end pipeline successfully generates summary videos without FPS-related crashes.
