### PR TITLE
fix: UnboundLocalError for video_fps when feature extraction is skipped

### DIFF
--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -63,6 +63,7 @@ def run_pipeline(video_path, ckpt_path, output_dir, device="cuda", fps=1.0,
     # 1. 특징 추출
     if os.path.exists(h5_path):
         print("\n[1/6] 특징 추출 - 기존 파일 발견, 스킵", flush=True)
+        video_fps = get_video_fps(video_path)
     else:
         print("\n[1/6] 특징 추출", flush=True)
         video_fps = extract_features_pipe(video_path, h5_path, device="cuda")


### PR DESCRIPTION
## Related Issues
> closes #41

<br>

## Overview
his PR fixes an `UnboundLocalError` for the variable `video_fps` that occurred in the scene detection step (`[3/6]`) when the feature extraction step (`[1/6]`) was skipped due to the presence of an existing feature file (`.h5`).

<br>

## Details of Changes
[x] The core issue was resolved by adding a single line to the `if` block that handles the skipping of feature extraction.
[x] This ensures that `video_fps` is guaranteed to be defined before being used later in the pipeline.
(You may also include a short summary of the workflow or logic if necessary.)

<br>

## Additional Notes (optional)
> Add related documents : `pipeline.py`