### PR TITLE
fix: Remove unreliable default 'device' args from pipeline functions

### DIFF
--- a/src/extract_features_module.py
+++ b/src/extract_features_module.py
@@ -121,7 +121,7 @@ def save_to_h5(features, output_h5):
         hf.create_dataset("features", data=features)
 
 # 특징 추출 및 TransNetV2 장면 분할 파이프라인
-def extract_features_pipe(video_path, output_h5, device="cuda"):
+def extract_features_pipe(video_path, output_h5, device):
     """
     비디오 파일에서 시각적 특징(feature)과 장면(scene) 정보를 추출하여 파일로 저장한다.
 

--- a/src/pgl_module.py
+++ b/src/pgl_module.py
@@ -9,7 +9,7 @@ def load_h5_features(h5_path):
     with h5py.File(h5_path, "r") as hf:
         return np.array(hf["features"])
 
-def predict_scores(model, features, device="cpu"):
+def predict_scores(model, features, device):
     # 모델을 통해 하이라이트 점수를 예측
     x = torch.from_numpy(features).float().to(device)
     if x.ndim == 2:
@@ -31,7 +31,7 @@ def load_model_checkpoint(model, ckpt_path, device):
     return model
 
 
-def run_pgl_module(ckpt_path, feature_h5, device="cpu"):
+def run_pgl_module(ckpt_path, feature_h5, device):
     """
     PGL-SUM 모델을 사용하여 각 세그먼트의 중요도 점수를 계산하고, Knapsack 알고리즘으로 최종 세그먼트를 선택한다.
     Args:

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -36,7 +36,7 @@ def get_video_fps(video_path):
         fps = vr.get_avg_fps()
     return fps
 
-def run_pipeline(video_path, ckpt_path, output_dir, device="cuda", fps=1.0,
+def run_pipeline(video_path, ckpt_path, output_dir, device, fps=1.0,
                 alpha=0.7, std_weight=0.3, top_ratio=0.2,
                 model_size="base", importance_weight=0.8, budget_time=None):
 
@@ -66,7 +66,7 @@ def run_pipeline(video_path, ckpt_path, output_dir, device="cuda", fps=1.0,
         video_fps = get_video_fps(video_path)
     else:
         print("\n[1/6] 특징 추출", flush=True)
-        video_fps = extract_features_pipe(video_path, h5_path, device="cuda")
+        video_fps = extract_features_pipe(video_path, h5_path, device)
 
     # 2. 중요도 기반 세그먼트 선택
     print("\n[2/6] 대표 프레임별 중요도 점수 산출 (PGL‑SUM)", flush=True)


### PR DESCRIPTION
## Related Issues
> closes #43

<br>

## Overview
> The fix is to remove all default assignments for the `device` argument, forcing explicit device specification during function calls to ensure stable and predictable execution.

<br>

## Details of Changes
- [x] Removed the default argument device="cuda" from the definition of the extract_features_pipe function.
- [x] Removed the default argument device="cpu" from the definition of the predict_scores function.
- [x] Updated all call sites of the affected functions to explicitly pass the device argument.


<br>

## Additional Notes (optional)
**Testing Instructions**
1. GPU Environment: Verify that the GPU is used correctly when `device='cuda'` is explicitly passed.
2. CPU Environment: Verify that the execution runs without errors when `device='cpu'` is explicitly passed.