### PR TITLE
Pull Request: Clarify '원본 대비 요약 비율' text ambiguity

### DIFF
--- a/server/public/static/pipelineRunner.js
+++ b/server/public/static/pipelineRunner.js
@@ -446,7 +446,7 @@ async function loadAndDisplayShortformTranscriptInternal(baseFilenameForTranscri
  */
 export function resetSummaryMetrics(excludeScore = false) {
   if (!excludeScore && summaryScoreValueEl) summaryScoreValueEl.textContent = 'N/A';
-  if (compressionRateValueEl) compressionRateValueEl.innerHTML = 'N/A <span class="metric-unit">요약</span>';
+  if (compressionRateValueEl) compressionRateValueEl.innerHTML = 'N/A <span class="metric-unit">로 요약</span>';
   if (keyScenesCountValueEl) keyScenesCountValueEl.innerHTML = 'N/A <span class="metric-unit">추출됨</span>';
   if (viewingTimeValueEl) viewingTimeValueEl.innerHTML = `<span class="time-original">N/A</span> → <span class="time-summary">N/A</span>`;
   if (summaryMethodValueEl) summaryMethodValueEl.innerHTML = 'N/A';
@@ -499,12 +499,12 @@ function updateSummaryMetricsFromServerData(data) {
 
   if (compressionRateValueEl) {
     if (data.summarization_ratio_percentage !== undefined) {
-      compressionRateValueEl.innerHTML = `${parseFloat(data.summarization_ratio_percentage).toFixed(1)}% <span class="metric-unit">요약</span>`;
+      compressionRateValueEl.innerHTML = `${parseFloat(data.summarization_ratio_percentage).toFixed(1)}% <span class="metric-unit">로 요약</span>`;
     } else if (data.summary_duration !== undefined && data.full_duration !== undefined && data.full_duration > 0) {
       const ratio = (data.summary_duration / data.full_duration) * 100;
-      compressionRateValueEl.innerHTML = `${parseFloat(ratio).toFixed(1)}% <span class="metric-unit">요약</span>`;
+      compressionRateValueEl.innerHTML = `${parseFloat(ratio).toFixed(1)}% <span class="metric-unit">로 요약</span>`;
     } else {
-      compressionRateValueEl.innerHTML = 'N/A <span class="metric-unit">요약</span>';
+      compressionRateValueEl.innerHTML = 'N/A <span class="metric-unit">로 요약</span>';
     }
   }
 


### PR DESCRIPTION
## Related Issues
Fixes: #44 — Clarify “원본 대비 요약 비율” text ambiguity

<br>

## Overview
This PR refines the UI text for video summarization ratio display to eliminate user confusion.
Previously, the phrase "원본 대비 요약 비율 n%" could be interpreted ambiguously — users were unsure whether n% represented the remaining length or the reduction ratio.

Now, the text explicitly indicates the meaning by changing it to "원본 대비 n%로 요약", clearly showing that the summarized video length is n% of the original.

<br>

## Details of Changes

- File Updated: pipelineRunner.js
- Updated Section: UI rendering logic for summarization ratio
- Before → After Example:
`
compressionRateValueEl.innerHTML = ${parseFloat(ratio).toFixed(1)}% <span class="metric-unit">요약</span>;
`
`
compressionRateValueEl.innerHTML = ${parseFloat(ratio).toFixed(1)}% <span class="metric-unit">로 요약</span>;
`

- The calculation logic remains unchanged (still (summary_duration / full_duration) * 100).
- The change solely improves text clarity for end users without affecting functional logic.

(You may also include a short summary of the workflow or logic if necessary.)

<br>

## Screenshots (optional)
> 
<img width="320" height="470" alt="image" src="https://github.com/user-attachments/assets/cfa4a0d7-052f-46dc-9b85-e316273022a6" />

<br>

## Additional Notes (optional)
This PR focuses purely on terminological clarification to improve UX.
The ratio remains a “remaining proportion” (summary/original), but the phrasing now communicates it unambiguously as “n%로 요약.”
