### PR TITLE
refactor(pipeline): auto-switch scene detection module based on CUDA availability

### DIFF
--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -70,10 +70,7 @@ def run_pipeline(video_path, ckpt_path, output_dir, device, fps=1.0,
         print("\n[3/6] 장면 분할 - 기존 파일 발견, 스킵", flush=True)
     else:
         print("\n[3/6]TransNetV2로 장면 전환 감지 중...")
-        if cuda_ok:
-            run_scene_detect_pipeline(video_path, device, scene_json)
-        else:
-            run_scene_detect_pipeline(video_path, scene_json, fps)
+        run_scene_detect_pipeline(video_path, scene_json)
 
     print("\n[4/6]세그먼트 중요도 산출 및 세그먼트 선택")
     run_segment_importance_pipeline(

--- a/src/scene_detection_module.py
+++ b/src/scene_detection_module.py
@@ -75,7 +75,7 @@ def save_segments_to_json(scenes, output_json):
     print(f"장면 구간 JSON 저장 완료: {output_json}")
 
 
-def run_scene_detect_pipeline(video_path, device, output_json):
+def run_scene_detect_pipeline(video_path, output_json):
     """
     장면 감지 파이프라인 실행
     
@@ -88,7 +88,7 @@ def run_scene_detect_pipeline(video_path, device, output_json):
     os.makedirs(os.path.dirname(output_json), exist_ok=True)
     
     # 장면 감지 실행
-    scenes = detect_scenes_transnetv2_pytorch(video_path, device)
+    scenes = detect_scenes_transnetv2_pytorch(video_path, device='cuda')
     
     # JSON 저장
     save_segments_to_json(scenes, output_json)

--- a/src/scene_detection_module_tf.py
+++ b/src/scene_detection_module_tf.py
@@ -1,7 +1,19 @@
 import os
 import json
+import cv2
 import numpy as np
 from transnetv2 import TransNetV2
+
+# 비디오 파일에서 FPS(초당 프레임 수)를 자동으로 계산
+def get_video_fps(video_path):
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        raise ValueError(f"비디오를 열 수 없습니다: {video_path}")
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    cap.release()
+    if fps <= 0:
+        raise ValueError("FPS를 읽을 수 없습니다.")
+    return fps
 
 # TransNetV2를 이용한 장면 전환 감지
 def detect_scenes_transnetv2(video_path, threshold=0.5):
@@ -36,8 +48,15 @@ def save_segments_to_json(scene_changes, output_json, total_frames, fps):
         json.dump(segment_data, f, ensure_ascii=False, indent=4)
     print("장면 구간 JSON 저장 완료")
 
-def run_scene_detect_pipeline(video_path, output_json, fps):    
+def run_scene_detect_pipeline(video_path, output_json):    
     os.makedirs(os.path.dirname(output_json), exist_ok=True)
 
+    # FPS 자동 계산
+    fps = get_video_fps(video_path)
+    print(f"자동 계산된 FPS: {fps:.2f}")
+
+    # 장면 전환 감지
     scene_changes, total_frames = detect_scenes_transnetv2(video_path)
+
+    # JSON 저장
     save_segments_to_json(scene_changes, output_json, total_frames, fps)


### PR DESCRIPTION

## Related Issues
closes #60 

<br>

## Overview
Refactored the pipeline to **automatically select the appropriate scene detection module** based on CUDA availability.
When CUDA is enabled, the pipeline now uses the PyTorch-based `scene_detection_module`.
If CUDA is not available, it automatically falls back to the TensorFlow/Numpy version `scene_detection_module_tf`.
This removes the need for manual imports or argument changes when switching environments.

<br>

## Details of Changes
- [x] Added dynamic import logic using `import_scene_module()` from `device_utils.py`
- [x] Removed static `scene_detection_module` import from `pipeline.py`
- [x] Simplified scene detection section in pipeline.py for maintainability  

<br>

## Screenshots (optional)
> no visual changes

<br>

## Review Notes (optional)
- Please confirm that both branches (CUDA on/off) correctly execute without manual modification.

<br>

## Additional Notes (optional)
> Add related documents, reference links, or testing instructions if applicable.
